### PR TITLE
extend matrix parameters with new php versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,27 +4,14 @@ orbs:
   ci: bigcommerce/internal@volatile
   php: bigcommerce/internal-php@volatile
 
-jobs:
-  tests:
-    parameters:
-      php-version:
-        type: string
-    executor:
-      name: php/php
-      php-version: << parameters.php-version >>
-    steps:
-      - ci/pre-setup
-      - php/composer-install
-      - php/unit-phpunit
-
 workflows:
   version: 2
   all-tests:
     jobs:
-      - tests:
+      - php/phpunit-tests:
           matrix:
             parameters:
-              php-version: ["8.0"]
+              php-version: [ "8.0", "8.1", "8.2" ]
       - php/composer-github:
           filters:
             tags:


### PR DESCRIPTION
## What/why
Extend CircleCI matrix parameters with new php versions so tests run against PHP 8.0, 8.1 and 8.2