### PR TITLE
Run CI against PHP 8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
       - php/phpunit-tests:
           matrix:
             parameters:
-              php-version: [ "8.0", "8.1", "8.2" ]
+              php-version: [ "8.0", "8.1", "8.2", "8.3" ]
       - php/composer-github:
           filters:
             tags:


### PR DESCRIPTION
## What
Run CI against PHP 8.3

## Why
The future is now

ping @bigcommerce/php