### PR TITLE
chore(platform): PHPMNT-177 Add PHP 8.4 to CircleCI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
       - php/phpunit-tests:
           matrix:
             parameters:
-              php-version: [ "8.0", "8.1", "8.2", "8.3" ]
+              php-version: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
       - php/composer-github:
           filters:
             tags:

--- a/src/Dflydev/Hawk/Header/Header.php
+++ b/src/Dflydev/Hawk/Header/Header.php
@@ -8,7 +8,7 @@ class Header
     private $fieldValue;
     private $attributes;
 
-    public function __construct($fieldName, $fieldValue, array $attributes = null)
+    public function __construct($fieldName, $fieldValue, ?array $attributes = null)
     {
         $this->fieldName = $fieldName;
         $this->fieldValue = $fieldValue;
@@ -25,7 +25,7 @@ class Header
         return $this->fieldValue;
     }
 
-    public function attributes(array $keys = null)
+    public function attributes(?array $keys = null)
     {
         if (null === $keys) {
             return $this->attributes;

--- a/src/Dflydev/Hawk/Header/HeaderFactory.php
+++ b/src/Dflydev/Hawk/Header/HeaderFactory.php
@@ -4,7 +4,7 @@ namespace Dflydev\Hawk\Header;
 
 class HeaderFactory
 {
-    public static function create($fieldName, array $attributes = null)
+    public static function create($fieldName, ?array $attributes = null)
     {
         $fieldValue = 'Hawk';
 
@@ -22,7 +22,7 @@ class HeaderFactory
         return new Header($fieldName, $fieldValue, $attributes);
     }
 
-    public static function createFromString($fieldName, $fieldValue, array $requiredKeys = null)
+    public static function createFromString($fieldName, $fieldValue, ?array $requiredKeys = null)
     {
         return static::create(
             $fieldName,

--- a/src/Dflydev/Hawk/Header/HeaderParser.php
+++ b/src/Dflydev/Hawk/Header/HeaderParser.php
@@ -4,7 +4,7 @@ namespace Dflydev\Hawk\Header;
 
 class HeaderParser
 {
-    public static function parseFieldValue($fieldValue, array $requiredKeys = null)
+    public static function parseFieldValue($fieldValue, ?array $requiredKeys = null)
     {
         if (!str_starts_with($fieldValue, 'Hawk')) {
             throw new NotHawkAuthorizationException;

--- a/src/Dflydev/Hawk/Server/UnauthorizedException.php
+++ b/src/Dflydev/Hawk/Server/UnauthorizedException.php
@@ -9,7 +9,7 @@ class UnauthorizedException extends \Exception
     private $attributes;
     private $header;
 
-    public function __construct($message = null, array $attributes = null)
+    public function __construct($message = null, ?array $attributes = null)
     {
         parent::__construct($message);
         $this->attributes = $attributes ?: array();


### PR DESCRIPTION
Jira: [PHPMNT-177](https://bigcommercecloud.atlassian.net/browse/PHPMNT-177)

## What/Why?
- Add PHP 8.4 to CircleCI test matrix
- Fix deprecation warnings https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-177]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ